### PR TITLE
Ensure that smbauth uses custom Kerberos dialer

### DIFF
--- a/smbauth/smbauth.go
+++ b/smbauth/smbauth.go
@@ -46,7 +46,8 @@ func Dialer(
 	ctx context.Context, creds *adauth.Credential, target *adauth.Target, options *Options,
 ) (*smb2.Dialer, error) {
 	smbCreds, err := dcerpcauth.DCERPCCredentials(ctx, creds, &dcerpcauth.Options{
-		Debug: options.debug,
+		Debug:          options.debug,
+		KerberosDialer: options.KerberosDialer,
 	})
 	if err != nil {
 		return nil, err
@@ -78,6 +79,7 @@ func Dialer(
 				KRB5Config:      krbConf,
 				CCachePath:      creds.CCache,
 				DisablePAFXFAST: true,
+				KDCDialer:       options.KerberosDialer,
 			}),
 		))
 


### PR DESCRIPTION
Simple fix to ensure that `smbauth.Dialer` uses the custom Kerberos dialer & passes it to dcerpcauth