### PR TITLE
fix(pkinit): allow full uint32 PKAuthenticator nonce range

### DIFF
--- a/pkinit/asn1.go
+++ b/pkinit/asn1.go
@@ -97,7 +97,7 @@ type PKAuthenticator struct {
 	// asn1
 	CUSec    int       `asn1:"tag:0,explicit"`
 	CTime    time.Time `asn1:"tag:1,explicit,generalized"`
-	Nonce    int       `asn1:"tag:2,explicit"`
+	Nonce    int64     `asn1:"tag:2,explicit"`
 	Checksum []byte    `asn1:"tag:3,explicit,optional"`
 }
 

--- a/pkinit/asn1_test.go
+++ b/pkinit/asn1_test.go
@@ -1,0 +1,38 @@
+package pkinit_test
+
+import (
+	"encoding/asn1"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/RedTeamPentesting/adauth/pkinit"
+)
+
+func TestPKAuthenticatorNonceAllowsUint32Range(t *testing.T) {
+	t.Parallel()
+
+	const maxUint32Nonce int64 = math.MaxUint32
+
+	authenticator := pkinit.PKAuthenticator{
+		CUSec: 123456,
+		CTime: time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC),
+		Nonce: maxUint32Nonce,
+	}
+
+	data, err := asn1.Marshal(authenticator)
+	if err != nil {
+		t.Fatalf("marshal PKAuthenticator: %v", err)
+	}
+
+	var decoded pkinit.PKAuthenticator
+
+	_, err = asn1.Unmarshal(data, &decoded)
+	if err != nil {
+		t.Fatalf("unmarshal PKAuthenticator: %v", err)
+	}
+
+	if decoded.Nonce != maxUint32Nonce {
+		t.Fatalf("nonce is %d instead of %d", decoded.Nonce, maxUint32Nonce)
+	}
+}

--- a/pkinit/asreq.go
+++ b/pkinit/asreq.go
@@ -53,7 +53,7 @@ func ConfigureASReq(
 		PKAuthenticator: PKAuthenticator{
 			CUSec:    int(now.UnixMicro() - now.Truncate(time.Millisecond).UnixMicro()),
 			CTime:    now,
-			Nonce:    mathRand.Intn(4294967295), //nolint:gosec
+			Nonce:    int64(mathRand.Uint32()), //nolint:gosec
 			Checksum: pkAuthenticatorChecksum,
 		},
 		ClientPublicValue: SubjectPublicKeyInfo{


### PR DESCRIPTION
PKINIT nonces can use the full uint32 range, but
the current code stores them in an int and
generates them with `Intn()`, which cannot
represent `MaxUint32` on all plats and also
excludes that value.

Store the nonce as int64 and generate it from
`Uint32()` so ASN.1 encoding can round-trip values
through the full uint32 range.

Fixes #8

### Proof

before:

```console
$ git cherry-pick 5e42b392ec1da560b5382094d1821478f70d92ca
[main 8084711] test(pkinit): (un)marshaling unmarshaling `MaxUint32`
 Date: Mon May 11 06:03:01 2026 +0700
 1 file changed, 38 insertions(+)
 create mode 100644 pkinit/asn1_test.go
$ go test -v -run "TestPKAuthenticatorNonceAllowsUint32Range" ./pkinit/
# github.com/RedTeamPentesting/adauth/pkinit_test [github.com/RedTeamPentesting/adauth/pkinit.test]
pkinit/asn1_test.go:20:10: cannot use maxUint32Nonce (constant 4294967295 of type int64) as int value in struct literal
pkinit/asn1_test.go:35:22: invalid operation: decoded.Nonce != maxUint32Nonce (mismatched types int and int64)
FAIL	github.com/RedTeamPentesting/adauth/pkinit [build failed]
FAIL
```

after (this patch):

```console
$ go test -v -run "TestPKAuthenticatorNonceAllowsUint32Range" ./pkinit/
=== RUN   TestPKAuthenticatorNonceAllowsUint32Range
=== PAUSE TestPKAuthenticatorNonceAllowsUint32Range
=== CONT  TestPKAuthenticatorNonceAllowsUint32Range
--- PASS: TestPKAuthenticatorNonceAllowsUint32Range (0.00s)
PASS
ok  	github.com/RedTeamPentesting/adauth/pkinit	0.003s
```